### PR TITLE
Introduce TrajectoryDataWriter abstraction

### DIFF
--- a/app/src/main/java/com/openpositioning/PositionMe/data/storage/FileTrajectoryWriter.java
+++ b/app/src/main/java/com/openpositioning/PositionMe/data/storage/FileTrajectoryWriter.java
@@ -1,4 +1,4 @@
-package com.openpositioning.PositionMe.data.local;
+package com.openpositioning.PositionMe.data.storage;
 
 import android.content.ContentValues;
 import android.content.Context;
@@ -21,15 +21,16 @@ import java.util.Date;
 import java.util.List;
 
 /**
- * DataFileManager encapsulates all file I/O and buffering logic.
+ * {@link TrajectoryDataWriter} implementation that writes records to a JSON
+ * file on the device. Data is buffered and periodically flushed to disk.
  *
  * It creates a new output file in the public Downloads folder, buffers JSON records,
  * automatically flushes them when a threshold is reached, and finalizes the file on close.
  *
  * @author Shu Gu
  */
-public class DataFileManager {
-    private static final String TAG = "DataFileManager";
+public class FileTrajectoryWriter implements TrajectoryDataWriter {
+    private static final String TAG = "FileTrajectoryWriter";
     private static final int FLUSH_THRESHOLD = 50;
 
     private Context context;
@@ -38,11 +39,11 @@ public class DataFileManager {
     private List<JSONObject> dataBuffer;
 
     /**
-     * Constructs a new DataFileManager instance.
+     * Create a writer that stores trajectory records to a file.
      *
      * @param context the application context
      */
-    public DataFileManager(Context context) {
+    public FileTrajectoryWriter(Context context) {
         this.context = context;
         this.dataBuffer = new ArrayList<>();
         prepareLocalFetch();
@@ -71,17 +72,19 @@ public class DataFileManager {
      *
      * @param record the JSON record to add
      */
+    @Override
     public void addRecord(JSONObject record) {
         dataBuffer.add(record);
         if (dataBuffer.size() >= FLUSH_THRESHOLD) {
-            flushBuffer();
+            flush();
         }
     }
 
     /**
      * Flushes all buffered records to the output file and clears the buffer.
      */
-    public void flushBuffer() {
+    @Override
+    public void flush() {
         if (dataBuffer.isEmpty() || outStream == null) {
             Log.d(TAG, "Flush skipped; buffer empty or output stream is null.");
             return;
@@ -103,7 +106,7 @@ public class DataFileManager {
      * For API >= Q, it also updates the file's pending flag so it becomes visible.
      */
     public void close() {
-        flushBuffer();
+        flush();
         if (outStream != null) {
             try {
                 outStream.close();

--- a/app/src/main/java/com/openpositioning/PositionMe/data/storage/TrajectoryDataWriter.java
+++ b/app/src/main/java/com/openpositioning/PositionMe/data/storage/TrajectoryDataWriter.java
@@ -1,0 +1,20 @@
+package com.openpositioning.PositionMe.data.storage;
+
+import org.json.JSONObject;
+
+/**
+ * Interface defining how trajectory data should be written.
+ */
+public interface TrajectoryDataWriter {
+    /**
+     * Add a single JSON record.
+     * @param record JSON data to append
+     */
+    void addRecord(JSONObject record);
+
+    /** Flush any buffered data to storage. */
+    void flush();
+
+    /** Finalize the writer and release resources. */
+    void close();
+}

--- a/app/src/main/java/com/openpositioning/PositionMe/presentation/fragment/CalibrationFragment.java
+++ b/app/src/main/java/com/openpositioning/PositionMe/presentation/fragment/CalibrationFragment.java
@@ -25,7 +25,7 @@ import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
 import com.google.android.material.button.MaterialButton;
 import com.openpositioning.PositionMe.R;
-import com.openpositioning.PositionMe.data.local.DataFileManager;
+import com.openpositioning.PositionMe.data.storage.TrajectoryDataWriter;
 import com.openpositioning.PositionMe.sensors.SensorFusion;
 import com.openpositioning.PositionMe.utils.CalibrationUtils;
 
@@ -59,7 +59,7 @@ public class CalibrationFragment extends Fragment {
 
     // Data references
     private SensorFusion sensorFusion;
-    private DataFileManager dataFileManager;
+    private TrajectoryDataWriter dataFileManager;
     private TrajectoryMapFragment trajectoryMapFragment;
 
     // Marker & calibration state
@@ -97,7 +97,8 @@ public class CalibrationFragment extends Fragment {
     public void setSensorFusion(SensorFusion sensorFusion) {
         this.sensorFusion = sensorFusion;
     }
-    public void setDataFileManager(DataFileManager dataFileManager) {
+
+    public void setTrajectoryDataWriter(TrajectoryDataWriter dataFileManager) {
         this.dataFileManager = dataFileManager;
     }
     public void setTrajectoryMapFragment(TrajectoryMapFragment mapFragment) {
@@ -463,7 +464,7 @@ public class CalibrationFragment extends Fragment {
 
         // Optionally flush or finalize data here
         if (dataFileManager != null) {
-            dataFileManager.flushBuffer();
+            dataFileManager.flush();
             // dataFileManager.close(); // Uncomment if you want to close the file entirely
         }
 

--- a/app/src/main/java/com/openpositioning/PositionMe/presentation/fragment/RecordingFragment.java
+++ b/app/src/main/java/com/openpositioning/PositionMe/presentation/fragment/RecordingFragment.java
@@ -21,7 +21,8 @@ import androidx.preference.PreferenceManager;
 
 import com.google.android.gms.maps.model.LatLng;
 import com.openpositioning.PositionMe.R;
-import com.openpositioning.PositionMe.data.local.DataFileManager;
+import com.openpositioning.PositionMe.data.storage.FileTrajectoryWriter;
+import com.openpositioning.PositionMe.data.storage.TrajectoryDataWriter;
 import com.openpositioning.PositionMe.sensors.SensorFusion;
 import com.openpositioning.PositionMe.sensors.SensorTypes;
 import com.openpositioning.PositionMe.sensors.Wifi;
@@ -45,11 +46,11 @@ import java.util.List;
  * </ul>
  *
  * <p>To use this fragment, the following references must be injected via setters:
- * {@link (SensorFusion)}, {@link (DataFileManager)},
+ * {@link (SensorFusion)}, {@link (TrajectoryDataWriter)},
  * and {@link (TrajectoryMapFragment)}.
  *
  * <p>The fragment supports both manual calibration tagging and continuous background data collection.
- * Data is written to {@link com.openpositioning.PositionMe.data.local.DataFileManager}.
+ * Data is written to {@link com.openpositioning.PositionMe.data.storage.FileTrajectoryWriter}.
  *
  * <p>This class works closely with:
  * <ul>
@@ -60,7 +61,7 @@ import java.util.List;
  *
  * @see TrajectoryMapFragment
  * @see SensorFusion
- * @see DataFileManager
+ * @see TrajectoryDataWriter
  */
 public class RecordingFragment extends Fragment {
 
@@ -74,7 +75,7 @@ public class RecordingFragment extends Fragment {
     private StatusBottomSheetFragment statusBottomSheet;
 
     private SensorFusion sensorFusion;
-    private DataFileManager dataFileManager;
+    private TrajectoryDataWriter dataFileManager;
     private SharedPreferences settings;
 
     private Handler refreshDataHandler;
@@ -106,7 +107,7 @@ public class RecordingFragment extends Fragment {
         Context context = requireActivity();
         settings = PreferenceManager.getDefaultSharedPreferences(context);
         refreshDataHandler = new Handler();
-        dataFileManager = new DataFileManager(requireContext());
+        dataFileManager = new FileTrajectoryWriter(requireContext());
     }
 
     @Nullable
@@ -151,7 +152,7 @@ public class RecordingFragment extends Fragment {
                     .commitNow();
         }
         calibrationFragment.setSensorFusion(sensorFusion);
-        calibrationFragment.setDataFileManager(dataFileManager);
+        calibrationFragment.setTrajectoryDataWriter(dataFileManager);
         calibrationFragment.setTrajectoryMapFragment(trajectoryMapFragment);
 
         // Show/hide bottom sheet


### PR DESCRIPTION
## Summary
- add `TrajectoryDataWriter` interface
- implement `FileTrajectoryWriter` and move former `DataFileManager` logic into it
- use the new writer in `RecordingFragment` and `CalibrationFragment`

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684191c66dbc8328864a4ca684d71918